### PR TITLE
fix: Correct ASCII art color marker processing

### DIFF
--- a/src/components/CLIEmulator.tsx
+++ b/src/components/CLIEmulator.tsx
@@ -53,12 +53,12 @@ const CLIEmulator: React.FC<CLIEmulatorProps> = ({ initialOutput = [] }) => {
           '\x02██║     ██║██║ ╚████║██║  ██╗██║███████╗\x02',
           '\x02╚═╝     ╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝╚══════╝\x02',
           '',
-          '\x03████████╗███████╗ ██████╗██╗  ██╗\x02',
-          '\x03╚══██╔══╝██╔════╝██╔════╝██║  ██║\x02',
-          '\x03   ██║   █████╗  ██║     ███████║\x02',
-          '\x03   ██║   ██╔══╝  ██║     ██╔══██║\x02',
-          '\x03   ██║   ███████╗╚██████╗██║  ██║\x02',
-          '\x03   ╚═╝   ╚══════╝ ╚═════╝╚═╝  ╚═╝\x02',
+          '\x03████████╗███████╗ ██████╗██╗  ██╗\x03',
+          '\x03╚══██╔══╝██╔════╝██╔════╝██║  ██║\x03',
+          '\x03   ██║   █████╗  ██║     ███████║\x03',
+          '\x03   ██║   ██╔══╝  ██║     ██╔══██║\x03',
+          '\x03   ██║   ███████╗╚██████╗██║  ██║\x03',
+          '\x03   ╚═╝   ╚══════╝ ╚═════╝╚═╝  ╚═╝\x03',
         ] : [
           '\x02██████╗ ██╗███╗   ██╗██╗  ██╗██╗███████╗████████╗███████╗ ██████╗██╗  ██╗\x02',
           '\x02██╔══██╗██║████╗  ██║██║ ██╔╝██║██╔════╝╚══██╔══╝██╔════╝██╔════╝██║  ██║\x02',
@@ -101,12 +101,12 @@ const CLIEmulator: React.FC<CLIEmulatorProps> = ({ initialOutput = [] }) => {
           '\x02██║     ██║██║ ╚████║██║  ██╗██║███████╗\x02',
           '\x02╚═╝     ╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝╚══════╝\x02',
           '',
-          '\x03████████╗███████╗ ██████╗██╗  ██╗\x02',
-          '\x03╚══██╔══╝██╔════╝██╔════╝██║  ██║\x02',
-          '\x03   ██║   █████╗  ██║     ███████║\x02',
-          '\x03   ██║   ██╔══╝  ██║     ██╔══██║\x02',
-          '\x03   ██║   ███████╗╚██████╗██║  ██║\x02',
-          '\x03   ╚═╝   ╚══════╝ ╚═════╝╚═╝  ╚═╝\x02',
+          '\x03████████╗███████╗ ██████╗██╗  ██╗\x03',
+          '\x03╚══██╔══╝██╔════╝██╔════╝██║  ██║\x03',
+          '\x03   ██║   █████╗  ██║     ███████║\x03',
+          '\x03   ██║   ██╔══╝  ██║     ██╔══██║\x03',
+          '\x03   ██║   ███████╗╚██████╗██║  ██║\x03',
+          '\x03   ╚═╝   ╚══════╝ ╚═════╝╚═╝  ╚═╝\x03',
         ] : [
           '\x02██████╗ ██╗███╗   ██╗██╗  ██╗██╗███████╗████████╗███████╗ ██████╗██╗  ██╗\x02',
           '\x02██╔══██╗██║████╗  ██║██║ ██╔╝██║██╔════╝╚══██╔══╝██╔════╝██╔════╝██║  ██║\x02',
@@ -1390,12 +1390,23 @@ const CLIEmulator: React.FC<CLIEmulatorProps> = ({ initialOutput = [] }) => {
           if (isUserInput) {
             cleanLine = line.substring(1);
             className += 'text-pink-300';
-          } else if (isCyberGlow) {
-            cleanLine = line.replace(/\x02/g, '');
-            className += 'text-pink-500 cyber-glow-pink';
-          } else if (isCyanGlow) {
-            cleanLine = line.replace(/\x03/g, '');
-            className += 'text-cyan-400 cyber-glow-cyan';
+          } else if (isCyberGlow || isCyanGlow) {
+            // Handle mixed color markers properly
+            cleanLine = line
+              .replace(/\x02([^\x02]*)\x02/g, '<span class="cyber-glow-pink text-pink-500">$1</span>')
+              .replace(/\x03([^\x03]*)\x03/g, '<span class="cyber-glow-cyan text-cyan-400">$1</span>')
+              .replace(/\x02/g, '')
+              .replace(/\x03/g, '');
+            
+            // If we have processed markers, we need to use dangerouslySetInnerHTML
+            if (line.includes('\x02') || line.includes('\x03')) {
+              return (
+                <div key={index} className={className}>
+                  <span dangerouslySetInnerHTML={{ __html: cleanLine }} />
+                </div>
+              );
+            }
+            className += 'text-pink-400/90';
           } else if (hasBoxDrawing) {
             className += 'text-pink-400/90 whitespace-nowrap overflow-x-auto font-mono text-[8px] leading-none';
           } else if (isInitialDisplay) {


### PR DESCRIPTION
## Summary
- Fix inconsistent color marker endings for TECH ASCII art in CLI emulator
- Improve marker processing logic to handle paired markers correctly  
- Ensure proper pink/cyan glow effects for PINKIE/TECH branding

## Changes Made
1. **Fixed color marker inconsistency**: Changed `\x03...\x02` to `\x03...\x03` for TECH ASCII art
2. **Enhanced marker processing**: Updated CLIEmulator.tsx to properly handle paired color markers using regex
3. **Improved rendering**: Added proper HTML span generation for colored text segments

## Technical Details
- Updated `generateBootSequence()` function to use consistent marker pairs
- Modified output rendering loop to process `\x02` and `\x03` markers as paired delimiters
- Implemented `dangerouslySetInnerHTML` for proper HTML rendering of colored segments

## Test Plan
- [x] Verify PINKIE text displays with pink glow effect
- [x] Verify TECH text displays with cyan glow effect  
- [x] Test on both mobile and desktop viewports
- [x] Confirm no regression in other CLI emulator functionality

## Related Issues
Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)